### PR TITLE
Added glightbox plugin

### DIFF
--- a/mkdocs/requirements.txt
+++ b/mkdocs/requirements.txt
@@ -16,3 +16,4 @@ mkdocs-section-index
 mkdocs-meta-descriptions-plugin
 mkdocs-with-pdf
 plantuml-markdown
+mkdocs-glightbox


### PR DESCRIPTION
This plugin allows opening images in docs in its true size

modified:   mkdocs/requirements.txt